### PR TITLE
fix: fix Chinese path error in Windows

### DIFF
--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -1,6 +1,7 @@
 #include <node.h>
 #include "DiffWorkerCallback.hpp"
 #include "PatchWorkerCallback.hpp"
+#include "Util.hpp"
 
 extern "C" {
   #include "c/bsdiff/bsdiff.h"
@@ -21,13 +22,25 @@ namespace bsdpNode {
     Nan::Callback *callback = new Nan::Callback(args[3].As<v8::Function>());
 
     Nan::Utf8String param0(args[0]);
+#ifdef WIN32
+    std::string oldfile = Utf8ToAnsi(*param0);
+#else
     std::string oldfile = std::string(*param0);
+#endif
 
     Nan::Utf8String param1(args[1]);
+#ifdef WIN32
+    std::string newfile = Utf8ToAnsi(*param1);
+#else
     std::string newfile = std::string(*param1);
+#endif
 
     Nan::Utf8String param2(args[2]);
-    std::string patchfile = std::string(*param2);
+#ifdef WIN32
+    std::string patchfile = Utf8ToAnsi(*param2);
+#else
+std::string patchfile = std::string(*param2);
+#endif
 
     DiffWorkerCallback* wc = new DiffWorkerCallback(callback, oldfile, newfile, patchfile);
     Nan::AsyncQueueWorker(wc);
@@ -52,7 +65,11 @@ namespace bsdpNode {
     char error[1024];
     memset(error, 0, sizeof error);
 
+#ifdef WIN32
+    int ret = bsdiff(error, Utf8ToAnsi(*oldfile).c_str(), Utf8ToAnsi(*newfile).c_str(), Utf8ToAnsi(*patchfile).c_str(), nullptr, nullptr);
+#else
     int ret = bsdiff(error, *oldfile, *newfile, *patchfile, nullptr, nullptr);
+#endif
 
     if(ret != 0)
       Nan::ThrowError(error);
@@ -69,13 +86,25 @@ namespace bsdpNode {
     Nan::Callback *callback = new Nan::Callback(args[3].As<v8::Function>());
 
     Nan::Utf8String param0(args[0]);
+#ifdef WIN32
+    std::string oldfile = Utf8ToAnsi(*param0);
+#else
     std::string oldfile = std::string(*param0);
+#endif
 
     Nan::Utf8String param1(args[1]);
+#ifdef WIN32
+    std::string newfile = Utf8ToAnsi(*param1);
+#else
     std::string newfile = std::string(*param1);
+#endif
 
     Nan::Utf8String param2(args[2]);
-    std::string patchfile = std::string(*param2);
+#ifdef WIN32
+    std::string patchfile = Utf8ToAnsi(*param2);
+#else
+std::string patchfile = std::string(*param2);
+#endif
 
     PatchWorkerCallback* wc = new PatchWorkerCallback(callback, oldfile, newfile, patchfile);
     Nan::AsyncQueueWorker(wc);
@@ -99,7 +128,11 @@ namespace bsdpNode {
     char error[1024];
     memset(error, 0, sizeof error);
 
+#ifdef WIN32
+    int ret = bspatch(error, Utf8ToAnsi(*oldfile).c_str(), Utf8ToAnsi(*newfile).c_str(), Utf8ToAnsi(*patchfile).c_str(), nullptr, nullptr);
+#else
     int ret = bspatch(error, *oldfile, *newfile, *patchfile, nullptr, nullptr);
+#endif
 
     if(ret != 0)
       Nan::ThrowError(error);

--- a/src/Util.cpp
+++ b/src/Util.cpp
@@ -1,0 +1,27 @@
+#include "Util.hpp"
+
+#include <Windows.h>
+
+namespace bsdpNode {
+#ifdef WIN32
+  std::string Utf8ToAnsi(const std::string& utf8str)
+  {
+    int wcsLen = ::MultiByteToWideChar(CP_UTF8, NULL, utf8str.c_str(), strlen(utf8str.c_str()), NULL, 0);
+    wchar_t* wszString = new wchar_t[wcsLen + 1];
+    ::MultiByteToWideChar(CP_UTF8, NULL, utf8str.c_str(), strlen(utf8str.c_str()), wszString, wcsLen);
+    wszString[wcsLen] = '\0';
+
+    int ansiLen = ::WideCharToMultiByte(CP_ACP, NULL, wszString, wcsLen, NULL, 0, NULL, NULL);
+    char* ansiString = new char[ansiLen + 1];
+    ::WideCharToMultiByte(CP_ACP, NULL, wszString, wcsLen, ansiString, ansiLen, NULL, NULL);
+    ansiString[ansiLen] = '\0';
+
+    std::string result = ansiString;
+
+    delete[] wszString;
+    delete[] ansiString;
+
+    return result;
+  }
+#endif
+}

--- a/src/Util.hpp
+++ b/src/Util.hpp
@@ -1,0 +1,12 @@
+#ifndef Uitl_H
+#define Uitl_H
+
+#include <string>
+
+namespace bsdpNode {
+#ifdef WIN32
+    std::string Utf8ToAnsi(const std::string& utf8str);
+#endif
+}
+
+#endif  // Uitl_H


### PR DESCRIPTION
![企业微信截图_16998587439752](https://github.com/Brouilles/bsdiff-node/assets/12172868/cffeb5a8-0df5-42f6-95c8-41646656a023)

>  realate to https://github.com/Brouilles/bsdiff-node/issues/21

In Windows, whenever using `diff` or `patch`, there would be an error "No such file or directory" with Chinese path string. I fixed the error in this PR.